### PR TITLE
Auto create incidents and updates them as outages and resolution of probe happens

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Solution that probes endpoints and updates cachet if there is an outage or recov
 ## Prerequisites
 
 You will need Cachet up and running. </br>
+Take a look at Cachet's installation guide [here](https://docs.cachethq.io/docs/installing-cachet) </br>
 You will also need a URL (I.E `http://cachet:8000/api/v1`) of that Cachet server and authentication (I.E `zlvNVV0VxKkuRL0WM5ww`) token
 
 ## Configuration

--- a/monitor/src/cachet/cachet.go
+++ b/monitor/src/cachet/cachet.go
@@ -54,7 +54,7 @@ func (c Cachet) UpdateComponent(componentid int, status string, monitor models.M
 	return monitor
 }
 
-func (c Cachet) CreateIncident(name string, message string, monitor models.Monitor , config models.Configuration ){
+func (c Cachet) CreateIncident(name string, message string, monitor models.Monitor , config models.Configuration ) models.CachetData {
 
 	fmt.Printf("Creating Cachet incident- name: %v componentid: %v message: %v \n", name,  monitor.Cachet.Componentid, message)
 	
@@ -90,8 +90,10 @@ func (c Cachet) CreateIncident(name string, message string, monitor models.Monit
 		if jsonErr != nil {
 			panic(jsonErr)
 		}
-
+		
 		defer resp.Body.Close()
+
+		return cachetComponent.Data
 	}
 
 }

--- a/monitor/src/cachet/cachet.go
+++ b/monitor/src/cachet/cachet.go
@@ -14,6 +14,7 @@ type Cachet struct{
 
 
 func (c Cachet) UpdateComponent(componentid int, status string, monitor models.Monitor, config models.Configuration ) models.Monitor {
+	
 	fmt.Printf("Updating Cachet component :  %v\n", monitor.Cachet.Componentid)
 	monitor.Status = status
 
@@ -49,4 +50,31 @@ func (c Cachet) UpdateComponent(componentid int, status string, monitor models.M
 	fmt.Printf("Update Cachet component - status : %v component: %v \n", status, componentid)
 
 	return monitor
+}
+
+func (c Cachet) CreateIncident(name string, message string, monitor models.Monitor , config models.Configuration ){
+
+	fmt.Printf("Creating Cachet incident- name: %v componentid: %v message: %v \n", name,  monitor.Cachet.Componentid, message)
+	
+	payload := strings.NewReader("{\n\t\"name\" : \"" + name + "\",\n\t\"message\" : \"" + message + "\",\n\t\"status\" : 1,\n\t\"component_id\" : 1,\n\t\"component_status\": 4,\n\t\"visible\": 1\n}")
+	req, reqErr := http.NewRequest("POST", config.Cachet.Server + "/incidents", payload)
+	req.Header.Add("content-type", "application/json")
+	req.Header.Add("X-Cachet-Token", config.Cachet.Token)
+
+	client := &http.Client{
+		Timeout: time.Second * 10,
+	}
+	resp, reqErr := client.Do(req)
+	
+	if resp != nil {
+		fmt.Printf("%#v \n", resp)
+	}
+	if reqErr != nil {
+		fmt.Printf("Error message : %#v\n", reqErr.Error()) 
+		panic(reqErr)
+	} else {
+		fmt.Println("Created incident success")
+		defer resp.Body.Close()
+	}
+
 }

--- a/monitor/src/cachet/cachet.go
+++ b/monitor/src/cachet/cachet.go
@@ -56,7 +56,7 @@ func (c Cachet) CreateIncident(name string, message string, monitor models.Monit
 
 	fmt.Printf("Creating Cachet incident- name: %v componentid: %v message: %v \n", name,  monitor.Cachet.Componentid, message)
 	
-	payload := strings.NewReader("{\n\t\"name\" : \"" + name + "\",\n\t\"message\" : \"" + message + "\",\n\t\"status\" : 1,\n\t\"component_id\" : 1,\n\t\"component_status\": 4,\n\t\"visible\": 1\n}")
+	payload := strings.NewReader("{\n\t\"name\" : \"" + name + "\",\n\t\"message\" : \"" + message + "\",\n\t\"status\" : 2,\n\t\"component_id\" : 1,\n\t\"component_status\": 4,\n\t\"visible\": 1\n}")
 	req, reqErr := http.NewRequest("POST", config.Cachet.Server + "/incidents", payload)
 	req.Header.Add("content-type", "application/json")
 	req.Header.Add("X-Cachet-Token", config.Cachet.Token)
@@ -78,3 +78,46 @@ func (c Cachet) CreateIncident(name string, message string, monitor models.Monit
 	}
 
 }
+
+func (c Cachet) UpdateIncident(incidentid int, status string, message string, monitor models.Monitor , config models.Configuration ){
+	
+		fmt.Printf("Updating Cachet incident- id: %v componentid: %v message: %v \n", strconv.Itoa(incidentid),  monitor.Cachet.Componentid, message)
+		
+		var statusid string = "0"
+		
+			switch status {
+				case "Investigating":
+					statusid = "1"
+				case "Identified":
+					statusid = "2"
+				case "Watching":
+					statusid = "3"
+				case "Fixed":
+					statusid = "4"
+			}
+
+		payload := strings.NewReader("{\n\t\"message\" : \"" + message + "\",\n\t\"status\" : " + statusid + "\n}")
+		
+		fmt.Println(payload)
+		var url string =  config.Cachet.Server + "/incidents/" + strconv.Itoa(incidentid) + "/updates"
+		req, reqErr := http.NewRequest("POST",url, payload)
+		req.Header.Add("content-type", "application/json")
+		req.Header.Add("X-Cachet-Token", config.Cachet.Token)
+	
+		client := &http.Client{
+			Timeout: time.Second * 10,
+		}
+		resp, reqErr := client.Do(req)
+		
+		if resp != nil {
+			fmt.Printf("%#v \n", resp)
+		}
+		if reqErr != nil {
+			fmt.Printf("Error message : %#v\n", reqErr.Error()) 
+			panic(reqErr)
+		} else {
+			fmt.Println("Update incident success")
+			defer resp.Body.Close()
+		}
+	
+	}

--- a/monitor/src/cachet/cachet.go
+++ b/monitor/src/cachet/cachet.go
@@ -96,11 +96,11 @@ func (c Cachet) UpdateIncident(incidentid int, status string, message string, mo
 					statusid = "4"
 			}
 
-		payload := strings.NewReader("{\n\t\"message\" : \"" + message + "\",\n\t\"status\" : " + statusid + "\n}")
+		payload := strings.NewReader("{\n\t\"message\" : \"" + message + "\",\n\t\"visible\" : 1,\n\t\"component_status\" : 1,\n\t\"component_id\" : 1,\n\t\"status\" : " + statusid + "\n}")
 		
 		fmt.Println(payload)
-		var url string =  config.Cachet.Server + "/incidents/" + strconv.Itoa(incidentid) + "/updates"
-		req, reqErr := http.NewRequest("POST",url, payload)
+		var url string =  config.Cachet.Server + "/incidents/" + strconv.Itoa(incidentid)
+		req, reqErr := http.NewRequest("PUT",url, payload)
 		req.Header.Add("content-type", "application/json")
 		req.Header.Add("X-Cachet-Token", config.Cachet.Token)
 	

--- a/monitor/src/controller/controller.go
+++ b/monitor/src/controller/controller.go
@@ -5,7 +5,7 @@ import (
 	 "net/http"
 	 log "github.com/sirupsen/logrus"
 	 "app/models"
-	
+	 cachet "app/cachet"
 	 "strconv"
 	 "io/ioutil"
 	 "encoding/json"
@@ -19,7 +19,16 @@ func (c Controller) StartMonitor(monitor models.Monitor, config models.Configura
 	fmt.Println("starting monitor: " + monitor.Name)
 	
 	monitor = Get_Cachet_Component_Statuses(monitor, config)
+	var cachet cachet.Cachet
 	
+	var cachetData,cachetErr = cachet.GetComponentPendingIncident(monitor.Cachet.Componentid, config)
+	
+	if cachetErr != nil {
+		panic(cachetErr)
+	}
+
+	monitor.Cachet.Incidentid = cachetData.Id
+
 	switch monitor.Type {
 		case "probe":
 			fmt.Printf("Controller: starting probe type monitor %v \n", monitor.Name)

--- a/monitor/src/controller/controller_probe.go
+++ b/monitor/src/controller/controller_probe.go
@@ -54,7 +54,9 @@ func Controller_Probe_Start(monitor models.Monitor, config models.Configuration)
 			
 			if failureCount == monitor.Maxfailures {
 				fmt.Printf("Monitor: %v max failures reached %v / %v\n", monitor.Name, failureCount ,monitor.Maxfailures)
-				monitor = cachet.UpdateComponent(monitor.Cachet.Componentid, "Failure", monitor, config)
+				//monitor = cachet.UpdateComponent(monitor.Cachet.Componentid, "Failure", monitor, config)
+				cachet.CreateIncident(monitor.Name + " - Incident raised", "```Error: " + reqErr.Error() + "```", monitor, config)
+				monitor.Status = "Failure"
 				fmt.Printf("Monitor: %v is now in a status: %v \n" , monitor.Name, monitor.Status)
 			}
 
@@ -65,7 +67,8 @@ func Controller_Probe_Start(monitor models.Monitor, config models.Configuration)
 			
 			if failureCount == monitor.Maxfailures {
 				fmt.Printf("Monitor: %v max failures reached %v / %v\n", monitor.Name, failureCount ,monitor.Maxfailures)
-				monitor = cachet.UpdateComponent(monitor.Cachet.Componentid, "Failure", monitor, config)
+				cachet.CreateIncident(monitor.Name + " - Incident raised", "```Error: " + reqErr.Error() + "```", monitor, config)
+				monitor.Status = "Failure"
 				fmt.Printf("Monitor: %v is now in a status: %v \n" , monitor.Name, monitor.Status)
 			}
 		//failure by status code from endpoint!	
@@ -75,7 +78,8 @@ func Controller_Probe_Start(monitor models.Monitor, config models.Configuration)
 			
 			if failureCount == monitor.Maxfailures {
 				fmt.Printf("Monitor: %v max failures reached %v / %v\n", monitor.Name, failureCount ,monitor.Maxfailures)
-				monitor = cachet.UpdateComponent(monitor.Cachet.Componentid, "Failure", monitor, config)
+				cachet.CreateIncident(monitor.Name + " - Incident raised", "```Error: " + reqErr.Error() + "```", monitor, config)
+				monitor.Status = "Failure"
 				fmt.Printf("Monitor: %v is now in a status: %v \n" , monitor.Name, monitor.Status)
 			}
 		//ongoing failure - response code
@@ -86,7 +90,11 @@ func Controller_Probe_Start(monitor models.Monitor, config models.Configuration)
 
 			if recoveryCount == recoveryReached {
 				fmt.Printf("Monitor: %v reached reached recovery status \n", monitor.Name)
+
+				
 				monitor = cachet.UpdateComponent(monitor.Cachet.Componentid, "Healthy", monitor, config)
+				cachet.UpdateIncident(12, "Fixed", "1", "We fixed it", monitor, config)
+				monitor.Status = "Healthy"
 				fmt.Printf("Monitor: %v is now in a status: %v \n" , monitor.Name, monitor.Status)
 			}
 

--- a/monitor/src/main.go
+++ b/monitor/src/main.go
@@ -10,7 +10,7 @@ import (
 	controller "app/controller"
 	"io/ioutil"
 	"github.com/ghodss/yaml"
-	cachet "app/cachet"
+	//cachet "app/cachet"
 	  
 )
 
@@ -55,11 +55,6 @@ func main() {
 	
 	var controller controller.Controller
 	for _, monitor := range config.Monitors {
-
-		var test cachet.Cachet
-		//test.CreateIncident(monitor.Name + " - Incident raised", "Error info: blah blah", monitor, config)
-		
-		test.UpdateIncident(12, "Fixed", "We fixed it", monitor, config)
 		controller.StartMonitor(monitor, config)
 	}
 

--- a/monitor/src/main.go
+++ b/monitor/src/main.go
@@ -10,6 +10,7 @@ import (
 	controller "app/controller"
 	"io/ioutil"
 	"github.com/ghodss/yaml"
+	cachet "app/cachet"
 	  
 )
 
@@ -54,6 +55,9 @@ func main() {
 	
 	var controller controller.Controller
 	for _, monitor := range config.Monitors {
+
+		var test cachet.Cachet
+		test.CreateIncident("test from monitor2", "this is a test2", monitor, config)
 		controller.StartMonitor(monitor, config)
 	}
 

--- a/monitor/src/main.go
+++ b/monitor/src/main.go
@@ -57,7 +57,9 @@ func main() {
 	for _, monitor := range config.Monitors {
 
 		var test cachet.Cachet
-		test.CreateIncident("test from monitor2", "this is a test2", monitor, config)
+		//test.CreateIncident(monitor.Name + " - Incident raised", "Error info: blah blah", monitor, config)
+		
+		test.UpdateIncident(12, "Fixed", "We fixed it", monitor, config)
 		controller.StartMonitor(monitor, config)
 	}
 

--- a/monitor/src/models/configuration.go
+++ b/monitor/src/models/configuration.go
@@ -20,6 +20,7 @@ type Monitor struct {
 
 type CachetItem struct {
 	Componentid int
+	Incidentid int
 }
 
 type Cachet struct {


### PR DESCRIPTION
Use cachet api to get component and related incidents upon start up of probe monitors.
When monitor reports failure, create incident and mark component as outage
When monitor recovers, update incident and mark component as healthy.
Ensure state is synchronised with monitor when this application restarts.
To do the persistence, we get latest component and incident data upon startup